### PR TITLE
listado de usuarios registrados y enlace en navbar

### DIFF
--- a/TodoListSpringBoot-main/src/main/java/madstodolist/controller/UsuarioController.java
+++ b/TodoListSpringBoot-main/src/main/java/madstodolist/controller/UsuarioController.java
@@ -1,0 +1,24 @@
+package madstodolist.controller;
+
+import madstodolist.dto.UsuarioData;
+import madstodolist.service.UsuarioService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.util.List;
+
+@Controller
+public class UsuarioController {
+
+    @Autowired
+    UsuarioService usuarioService;
+
+    @GetMapping("/registrados")
+    public String listadoUsuarios(Model model) {
+        List<UsuarioData> usuarios = usuarioService.allUsuarios();
+        model.addAttribute("usuarios", usuarios);
+        return "listadoUsuarios";
+    }
+}

--- a/TodoListSpringBoot-main/src/main/java/madstodolist/service/UsuarioService.java
+++ b/TodoListSpringBoot-main/src/main/java/madstodolist/service/UsuarioService.java
@@ -10,7 +10,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
+
+import java.util.stream.StreamSupport;
+
 
 @Service
 public class UsuarioService {
@@ -72,4 +76,14 @@ public class UsuarioService {
             return modelMapper.map(usuario, UsuarioData.class);
         }
     }
+    
+    
+    @Transactional(readOnly = true)
+    public List<UsuarioData> allUsuarios() {
+        Iterable<Usuario> usuarios = usuarioRepository.findAll();
+        return StreamSupport.stream(usuarios.spliterator(), false)
+        .map(usuario -> modelMapper.map(usuario, UsuarioData.class))
+        .toList();
+    }
+
 }

--- a/TodoListSpringBoot-main/src/main/resources/templates/fragments/navbar.html
+++ b/TodoListSpringBoot-main/src/main/resources/templates/fragments/navbar.html
@@ -5,9 +5,14 @@
 
     <div class="collapse navbar-collapse" id="navbarNav">
       <ul class="navbar-nav me-auto">
-        <!-- Mostrar "Tareas" solo si el usuario está logeado -->
+        <!-- Mostrar "Tareas" si logeado -->
         <li class="nav-item" th:if="${session.usuario != null}">
           <a class="nav-link" th:href="@{'/usuarios/' + ${session.usuario.id} + '/tareas'}">Tareas</a>
+        </li>
+
+        <!-- Mostrar "Usuarios" si logeado -->
+        <li class="nav-item" th:if="${session.usuario != null}">
+          <a class="nav-link" th:href="@{/registrados}">Usuarios</a>
         </li>
       </ul>
 

--- a/TodoListSpringBoot-main/src/main/resources/templates/listadoUsuarios.html
+++ b/TodoListSpringBoot-main/src/main/resources/templates/listadoUsuarios.html
@@ -36,3 +36,5 @@
 <div th:replace="fragments :: javascript"></div>
 </body>
 </html>
+
+

--- a/TodoListSpringBoot-main/src/main/resources/templates/listadoUsuarios.html
+++ b/TodoListSpringBoot-main/src/main/resources/templates/listadoUsuarios.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<head th:replace="fragments :: head (titulo='Usuarios registrados')"></head>
+
+<body>
+<div th:replace="fragments/navbar :: navbar"></div>
+
+<div class="container mt-4">
+    <h1>Usuarios registrados</h1>
+
+    <div th:if="${usuarios.isEmpty()}">
+        <p>No hay usuarios registrados en el sistema.</p>
+    </div>
+
+    <div th:unless="${usuarios.isEmpty()}">
+        <table class="table table-bordered table-striped">
+            <thead>
+            <tr>
+                <th>ID</th>
+                <th>Email</th>
+                <th>Nombre</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="usuario : ${usuarios}">
+                <td th:text="${usuario.id}">1</td>
+                <td th:text="${usuario.email}">correo@ejemplo.com</td>
+                <td th:text="${usuario.nombre}">Nombre</td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<div th:replace="fragments :: javascript"></div>
+</body>
+</html>


### PR DESCRIPTION
Se implementa la funcionalidad correspondiente al Issue #3 (listado de usuarios registrados).

### Cambios realizados:

- ✅ Se creó el controlador `UsuarioController` con ruta `/registrados`
- ✅ Se implementó el método `allUsuarios()` en `UsuarioService`
- ✅ Se creó la vista `listadoUsuarios.html` con tabla de ID, Email y Nombre
- ✅ Se añadió el enlace a `Usuarios` en el navbar (visible solo si el usuario está logeado)
- ✅ Se verifica sesión mediante `session.usuario`
- ✅ El diseño se mantiene coherente con Bootstrap

### Resultado:

Al iniciar sesión, se puede acceder al listado de usuarios desde el navbar o escribiendo `/registrados` directamente.

Closes #3